### PR TITLE
Step14

### DIFF
--- a/src/main/java/kr/hhplus/be/server/api/coupon/controller/CouponController.java
+++ b/src/main/java/kr/hhplus/be/server/api/coupon/controller/CouponController.java
@@ -4,11 +4,9 @@ import kr.hhplus.be.server.api.coupon.dto.IssueCouponRequest;
 import kr.hhplus.be.server.api.coupon.dto.IssueCouponResponse;
 import kr.hhplus.be.server.domain.coupon.CouponService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/coupon")
@@ -19,10 +17,18 @@ public class CouponController implements CouponSwaggerApiSpec {
     @Override
     @PostMapping("/issue")
     public ResponseEntity<IssueCouponResponse> issue(@RequestBody IssueCouponRequest request) {
-        IssueCouponResponse response = IssueCouponResponse.from(couponService.issueWithLock(request.to()));
+        IssueCouponResponse response = IssueCouponResponse.from(couponService.issue(request.to()));
 
         return ResponseEntity
                 .status(201)
                 .body(response);
+    }
+
+    @Override
+    @PostMapping("/quantity/initialize/{couponId}")
+    public ResponseEntity<Void> initializeQuantity(@PathVariable Long couponId) {
+        // for admin
+        couponService.initializeCouponQuantity(couponId);
+        return ResponseEntity.status(HttpStatus.CREATED).build();
     }
 }

--- a/src/main/java/kr/hhplus/be/server/api/coupon/controller/CouponSwaggerApiSpec.java
+++ b/src/main/java/kr/hhplus/be/server/api/coupon/controller/CouponSwaggerApiSpec.java
@@ -1,6 +1,7 @@
 package kr.hhplus.be.server.api.coupon.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -13,6 +14,8 @@ import kr.hhplus.be.server.api.coupon.dto.IssueCouponRequest;
 import kr.hhplus.be.server.api.coupon.dto.IssueCouponResponse;
 import kr.hhplus.be.server.global.exception.ErrorResponse;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 
 @Tag(name = "Coupon API", description = "쿠폰 API")
 public interface CouponSwaggerApiSpec {
@@ -71,4 +74,31 @@ public interface CouponSwaggerApiSpec {
                     required = true,
                     content = @Content(schema = @Schema(implementation = IssueCouponRequest.class))
             ) IssueCouponRequest request);
+
+
+    @Operation(
+            summary = "쿠폰 수량 초기화",
+            description = "Redis에 쿠폰의 수량 정보를 초기화합니다. 쿠폰 엔티티에 설정된 총 수량으로 초기화됩니다.",
+            tags = {"Coupon API"}
+    )
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "201",
+                    description = "수량 초기화 성공"
+            ),
+            @ApiResponse(
+                    responseCode = "404",
+                    description = "쿠폰이 모두 소진된 경우",
+                    content = @Content(
+                            schema = @Schema(implementation = ErrorResponse.class),
+                            examples = @ExampleObject(
+                                    value = """
+                                        {
+                                            "code": 404,
+                                            "message": "존재하지 않는 쿠폰입니다."
+                                        }
+                                    """
+                            ))),
+    })
+    ResponseEntity<Void> initializeQuantity(@Parameter(description = "쿠폰 ID", example = "1") Long couponId);
 }

--- a/src/main/java/kr/hhplus/be/server/domain/coupon/CouponIssuanceManager.java
+++ b/src/main/java/kr/hhplus/be/server/domain/coupon/CouponIssuanceManager.java
@@ -1,0 +1,9 @@
+package kr.hhplus.be.server.domain.coupon;
+
+public interface CouponIssuanceManager {
+    int decreaseAndGetQuantity(Long couponId);
+    int increaseAndGetQuantity(Long couponId);
+    int getQuantity(Long couponId);
+    void initializeQuantity(Long couponId, int quantity);
+    boolean saveIssuedUser(Long couponId, Long userId);
+}

--- a/src/main/java/kr/hhplus/be/server/domain/coupon/CouponService.java
+++ b/src/main/java/kr/hhplus/be/server/domain/coupon/CouponService.java
@@ -53,4 +53,11 @@ public class CouponService {
     private void rollbackQuantity(Long couponId) {
         couponIssuanceManager.increaseAndGetQuantity(couponId);
     }
+
+    @Transactional(readOnly = true)
+    public void initializeCouponQuantity(Long couponId) {
+        Coupon coupon = couponRepository.findById(couponId)
+                .orElseThrow(() -> new BusinessException(CouponErrorCode.COUPON_NOT_FOUND));
+        couponIssuanceManager.initializeQuantity(couponId, coupon.getTotalQuantity());
+    }
 }

--- a/src/main/java/kr/hhplus/be/server/domain/coupon/model/Coupon.java
+++ b/src/main/java/kr/hhplus/be/server/domain/coupon/model/Coupon.java
@@ -35,20 +35,8 @@ public class Coupon extends BaseEntity {
     @Column(nullable = false)
     private int totalQuantity;
 
-    public IssuedCoupon issue(Long userId) {
-        validateRemainingQuantity();
-        decreaseQuantity();
-        return new IssuedCoupon(this, userId);
-    }
-
-    private void validateRemainingQuantity() {
-        if (totalQuantity <= 0) {
-            throw new BusinessException(CouponErrorCode.COUPON_STOCK_DEPLETED);
-        }
-    }
-
-    private void decreaseQuantity() {
-        totalQuantity --;
+    public void updateQuantity(int quantity) {
+        this.totalQuantity = quantity;
     }
 
     public void validateUsage(Long orderAmount) {

--- a/src/main/java/kr/hhplus/be/server/infrastructure/coupon/store/RedisCouponIssuanceManager.java
+++ b/src/main/java/kr/hhplus/be/server/infrastructure/coupon/store/RedisCouponIssuanceManager.java
@@ -1,0 +1,53 @@
+package kr.hhplus.be.server.infrastructure.coupon.store;
+
+import kr.hhplus.be.server.domain.coupon.CouponIssuanceManager;
+import lombok.RequiredArgsConstructor;
+import org.redisson.api.RAtomicLong;
+import org.redisson.api.RSet;
+import org.redisson.api.RedissonClient;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class RedisCouponIssuanceManager implements CouponIssuanceManager {
+    private final RedissonClient redissonClient;
+
+    private static final String COUPON_QUANTITY_PREFIX = "coupon:quantity";
+    private static final String ISSUED_USER_PREFIX = "coupon:issued";
+
+    @Override
+    public int decreaseAndGetQuantity(Long couponId) {
+        return (int) getQuantityAtomicLong(couponId).decrementAndGet();
+    }
+
+    @Override
+    public int increaseAndGetQuantity(Long couponId) {
+        return (int) getQuantityAtomicLong(couponId).incrementAndGet();
+    }
+
+    @Override
+    public int getQuantity(Long couponId) {
+        return (int) getQuantityAtomicLong(couponId).get();
+    }
+
+    @Override
+    public void initializeQuantity(Long couponId, int quantity) {
+        getQuantityAtomicLong(couponId).set(quantity);
+    }
+
+    private RAtomicLong getQuantityAtomicLong(Long couponId) {
+        String key = String.join(":", COUPON_QUANTITY_PREFIX, couponId.toString());
+        return redissonClient.getAtomicLong(key);
+    }
+
+    @Override
+    public boolean saveIssuedUser(Long couponId, Long userId) {
+        RSet<Long> issuedUserSet = getIssuedUserSet(couponId);
+        return issuedUserSet.add(userId);
+    }
+
+    private RSet<Long> getIssuedUserSet(Long couponId) {
+        String key = String.join(":", ISSUED_USER_PREFIX, couponId.toString());
+        return redissonClient.getSet(key);
+    }
+}

--- a/src/test/java/kr/hhplus/be/server/application/payment/PaymentFacadeIntegrationTest.java
+++ b/src/test/java/kr/hhplus/be/server/application/payment/PaymentFacadeIntegrationTest.java
@@ -37,6 +37,9 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.redisson.api.RAtomicLong;
+import org.redisson.api.RSet;
+import org.redisson.api.RedissonClient;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.dao.OptimisticLockingFailureException;
@@ -90,6 +93,8 @@ public class PaymentFacadeIntegrationTest {
     private CouponJpaRepository couponJpaRepository;
     @Autowired
     private IssuedCouponJpaRepository issuedCouponJpaRepository;
+    @Autowired
+    private RedissonClient redissonClient;
 
     @Nested
     @DisplayName("기본 결제 기능")
@@ -207,8 +212,16 @@ public class PaymentFacadeIntegrationTest {
             Coupon coupon = coupon(100);
             couponJpaRepository.saveAndFlush(coupon);
 
+            RAtomicLong quantity = redissonClient.getAtomicLong(String.join(":", "coupon:quantity", coupon.getId().toString()));
+            quantity.delete();
+
+            RSet<Long> issuedUserSet = redissonClient.getSet(String.join(":", "coupon:issued", coupon.getId().toString()));
+            issuedUserSet.delete();
+
+            couponService.initializeCouponQuantity(coupon.getId());
+
             IssueCouponCommand issueCouponCommand = new IssueCouponCommand(user.getId(), coupon.getId());
-            couponService.issueWithLock(issueCouponCommand);
+            couponService.issue(issueCouponCommand);
         }
 
         @Test
@@ -257,8 +270,16 @@ public class PaymentFacadeIntegrationTest {
             Coupon coupon = coupon(100);
             couponJpaRepository.saveAndFlush(coupon);
 
+            RAtomicLong quantity = redissonClient.getAtomicLong(String.join(":", "coupon:quantity", coupon.getId().toString()));
+            quantity.delete();
+
+            RSet<Long> issuedUserSet = redissonClient.getSet(String.join(":", "coupon:issued", coupon.getId().toString()));
+            issuedUserSet.delete();
+
+            couponService.initializeCouponQuantity(coupon.getId());
+
             IssueCouponCommand issueCouponCommand = new IssueCouponCommand(user.getId(), coupon.getId());
-            couponService.issueWithLock(issueCouponCommand);
+            couponService.issue(issueCouponCommand);
         }
 
         @Test
@@ -319,8 +340,16 @@ public class PaymentFacadeIntegrationTest {
             Coupon coupon = coupon(100);
             couponJpaRepository.saveAndFlush(coupon);
 
+            RAtomicLong quantity = redissonClient.getAtomicLong(String.join(":", "coupon:quantity", coupon.getId().toString()));
+            quantity.delete();
+
+            RSet<Long> issuedUserSet = redissonClient.getSet(String.join(":", "coupon:issued", coupon.getId().toString()));
+            issuedUserSet.delete();
+
+            couponService.initializeCouponQuantity(coupon.getId());
+
             IssueCouponCommand issueCouponCommand = new IssueCouponCommand(user1.getId(), coupon.getId());
-            couponService.issueWithLock(issueCouponCommand);
+            couponService.issue(issueCouponCommand);
         }
 
         @Test

--- a/src/test/java/kr/hhplus/be/server/domain/coupon/CouponTest.java
+++ b/src/test/java/kr/hhplus/be/server/domain/coupon/CouponTest.java
@@ -12,37 +12,6 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class CouponTest {
     @Nested
-    @DisplayName("쿠폰 발급")
-    class IssueCouponTest {
-        @Test
-        void 쿠폰_잔여_수량이_없으면_쿠폰_발급에_실패한다() {
-            // given
-            Long userId = 1L;
-            Coupon couponWithoutStock = couponWithoutStock();
-
-            // when & then
-            assertThatThrownBy(() -> couponWithoutStock.issue(userId))
-                    .isInstanceOf(BusinessException.class)
-                    .hasMessage(CouponErrorCode.COUPON_STOCK_DEPLETED.getMessage());
-        }
-
-        @Test
-        void 쿠폰_발급_시_잔여수량이_차감된다() {
-            // given
-            Long userId = 1L;
-            Coupon coupon = coupon();
-            int initialQuantity = coupon.getTotalQuantity();
-
-            // when
-            coupon.issue(userId);
-
-            // then
-            int actualQuantity = coupon.getTotalQuantity();
-            assertThat(actualQuantity).isEqualTo(initialQuantity - 1);
-        }
-    }
-
-    @Nested
     @DisplayName("쿠폰 사용 검증")
     class UseCouponTest {
         @Test


### PR DESCRIPTION
### **커밋 링크**

**쿠폰 발급 로직 개선**
- **커밋:** 567fced1
- **내용:** 기존에 DB 락을 사용하여 동시성을 제어하던 방식에서 레디스를 활용하여 동시성 제어를 하는 방식으로 변경했습니다.
- **변경사항**
  - 쿠폰 잔여 수량을 String 자료 구조에 저장, 쿠폰 발급 시 차감하도록 변경
  - 쿠폰을 발급한 유저를 Set 자료 구조에 저장, 쿠폰 발급 시 Set에서 확인하도록 변경
- **기대효과**
  - DB Lock 을 삭제하여 데이터베이스 부하를 줄이고, Lock 대기로 인한 병목을 줄임
  - 데이터베이스 작업 전에 유효성을 먼저 검증하여 불필요한 데이터베이스 접근을 방지
- **개선사항**
  - 선착순 쿠폰 발급이 종료되었을 때(잔여 수량이 0일 때) 레디스에서 데이터를 삭제하는 로직
  
**레디스에 쿠폰 수량 초기화 API**
- **커밋:** c06e8f53
- **내용:** 쿠폰 발급을 시작하려면, 쿠폰 잔여 수량을 레디스에 세팅해주어야 합니다. 따라서, 관리자를 위한 초기화 API를 추가했습니다.

**테스트**
- **커밋:** 78aad7b6
- **내용:** 쿠폰 발급 기능 변경에 맞춰 기존 테스트 수정하고, 아래 테스트를 추가했습니다. (커밋을 못나눴습니다..🥲)
  - 통합 테스트
    - 동일 사용자 중복 발급 확인 테스트
    - 쿠폰 수량 동시성 테스트
  - 단위 테스트
    - 쿠폰 수량 부족 시 실패 테스트

- **커밋:**  6e2a08c7
- **내용:** 쿠폰 수량 초기화 기능 테스트 추가

---
### **리뷰 포인트(질문)**
- 리뷰 포인트 1
  적절한 자료 구조를 사용한 것이 맞는지 궁금합니다.
- 리뷰 포인트 2
  레디스를 사용하다보니, `ProductService.issue` 메서드가 너무 복잡해지는 것 같다는 생각이 들었습니다.
  현재 책임이 적절히 분리되지 않아 복잡해진 것인지, 이 정도의 복잡도는 괜찮은 것인지 판단이 잘 되지 않습니다.
  개선할 수 있는 방향이 있으면 피드백 부탁드립니다.
- 리뷰 포인트 3
  스케줄러, 캐시, 레디스 등이 새로 들어오니, 어느 패키지에 두어야할까 고민이 많습니다.
  현재 적절한 위치에 있는지 피드백 부탁드립니다.
