### PR TITLE
Step18

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,11 +11,57 @@ services:
       - MYSQL_DATABASE=hhplus
     volumes:
       - ./data/mysql/:/var/lib/mysql
+
   redis:
     image: redis:7
     ports:
       - "6379:6379"
 
+  zookeeper:
+    image: bitnami/zookeeper:latest
+    container_name: zookeeper
+    environment:
+      - ALLOW_ANONYMOUS_LOGIN=yes
+    ports:
+      - "2181:2181"
+    networks:
+      - kafka-network
+
+  kafka:
+    image: bitnami/kafka:latest
+    container_name: kafka
+    depends_on:
+      - zookeeper
+    ports:
+      - "9092:9092"
+    environment:
+      - KAFKA_CFG_ZOOKEEPER_CONNECT=zookeeper:2181
+      - ALLOW_PLAINTEXT_LISTENER=yes
+      - KAFKA_CFG_LISTENERS=PLAINTEXT://:9092,INTERNAL://kafka:29092
+      - KAFKA_CFG_ADVERTISED_LISTENERS=PLAINTEXT://localhost:9092,INTERNAL://kafka:29092
+      - KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP=PLAINTEXT:PLAINTEXT,INTERNAL:PLAINTEXT
+      - KAFKA_CFG_INTER_BROKER_LISTENER_NAME=INTERNAL
+      - KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR=1
+      - KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR=1
+    networks:
+      - kafka-network
+
+  kafka-ui:
+    image: provectuslabs/kafka-ui:latest
+    container_name: kafka-ui
+    depends_on:
+      - kafka
+    ports:
+      - "8081:8080"
+    environment:
+      - KAFKA_CLUSTERS_0_NAME=local
+      - KAFKA_CLUSTERS_0_BOOTSTRAPSERVERS=kafka:29092
+      - KAFKA_CLUSTERS_0_ZOOKEEPER=zookeeper:2181
+    networks:
+      - kafka-network
+
 networks:
   default:
+    driver: bridge
+  kafka-network:
     driver: bridge

--- a/src/main/java/kr/hhplus/be/server/event/payment/handler/PaymentEventHandler.java
+++ b/src/main/java/kr/hhplus/be/server/event/payment/handler/PaymentEventHandler.java
@@ -1,23 +1,56 @@
 package kr.hhplus.be.server.event.payment.handler;
 
-import kr.hhplus.be.server.application.dataplatform.DataPlatformPort;
-import kr.hhplus.be.server.application.dataplatform.dto.PaymentInfo;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import kr.hhplus.be.server.event.payment.model.PaymentCompletedEvent;
+import kr.hhplus.be.server.event.payment.outbox.PaymentEventOutbox;
+import kr.hhplus.be.server.event.payment.outbox.PaymentEventOutboxService;
 import lombok.RequiredArgsConstructor;
-import org.springframework.scheduling.annotation.Async;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.event.TransactionPhase;
 import org.springframework.transaction.event.TransactionalEventListener;
 
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class PaymentEventHandler {
-    private final DataPlatformPort dataPlatformPort;
+    private final PaymentEventOutboxService paymentEventOutboxService;
+    private final KafkaTemplate<String, String> kafkaTemplate;
+    private final ObjectMapper objectMapper;
 
-    @Async
+    private final String TOPIC = "payment-event";
+
+    @TransactionalEventListener(phase = TransactionPhase.BEFORE_COMMIT)
+    public void saveToOutbox(PaymentCompletedEvent event) {
+        try {
+            paymentEventOutboxService.save(PaymentEventOutbox.from(event, objectMapper.writeValueAsString(event)));
+        } catch (JsonProcessingException e) {
+            // 메인 비즈니스는 롤백 X
+            log.error("직렬화 중 예외 발생 paymentId={}", event.getPaymentId());
+        }
+    }
+
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
-    public void sendToDataPlatform(PaymentCompletedEvent event) {
-        PaymentInfo paymentInfo = new PaymentInfo(event.getPaymentId(), event.getPaidAt());
-        dataPlatformPort.sendPaymentInfo(paymentInfo);
+    public void publish(PaymentCompletedEvent event) {
+        try {
+            kafkaTemplate.send(TOPIC, objectMapper.writeValueAsString(event));
+        } catch (JsonProcessingException e) {
+            //
+            log.error("직렬화 중 예외 발생 paymentId={}", event.getPaymentId());
+        }
+    }
+
+    @KafkaListener(topics = "payment-event", groupId = TOPIC)
+    public void checkPublish(String payload) {
+        try {
+            PaymentCompletedEvent event = objectMapper.readValue(payload, PaymentCompletedEvent.class);
+            paymentEventOutboxService.checkPublished(event.getPaymentId());
+        } catch (JsonProcessingException e) {
+            // 메인 비즈니스는 롤백 X
+            log.error("역직렬화 중 예외 발생, payload={}", payload);
+        }
     }
 }

--- a/src/main/java/kr/hhplus/be/server/event/payment/model/PaymentCompletedEvent.java
+++ b/src/main/java/kr/hhplus/be/server/event/payment/model/PaymentCompletedEvent.java
@@ -2,10 +2,12 @@ package kr.hhplus.be.server.event.payment.model;
 
 import kr.hhplus.be.server.domain.payment.model.Payment;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
 
 @Getter
+@NoArgsConstructor
 public class PaymentCompletedEvent {
     private Long paymentId;
     private Long orderId;
@@ -13,6 +15,7 @@ public class PaymentCompletedEvent {
     private Long discountAmount;
     private Long finalAmount;
     private LocalDateTime paidAt;
+    private LocalDateTime occurredAt;
 
     public static PaymentCompletedEvent from(Payment payment) {
         PaymentCompletedEvent paymentCompletedEvent = new PaymentCompletedEvent();
@@ -23,6 +26,7 @@ public class PaymentCompletedEvent {
         paymentCompletedEvent.discountAmount = payment.getDiscountAmount();
         paymentCompletedEvent.finalAmount = payment.getFinalAmount();
         paymentCompletedEvent.paidAt = payment.getPaidAt();
+        paymentCompletedEvent.occurredAt = LocalDateTime.now();
 
         return paymentCompletedEvent;
     }

--- a/src/main/java/kr/hhplus/be/server/event/payment/outbox/PaymentEventOutbox.java
+++ b/src/main/java/kr/hhplus/be/server/event/payment/outbox/PaymentEventOutbox.java
@@ -1,0 +1,41 @@
+package kr.hhplus.be.server.event.payment.outbox;
+
+import jakarta.persistence.*;
+import kr.hhplus.be.server.event.payment.model.PaymentCompletedEvent;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "payment_event_outbox")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class PaymentEventOutbox {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private long id;
+    @Column(nullable = false)
+    private long paymentId;
+    @Column(nullable = false)
+    private String payload;
+    @Column(nullable = false)
+    private LocalDateTime createdAt;
+    @Column(nullable = false)
+    private boolean published;
+
+    public static PaymentEventOutbox from(PaymentCompletedEvent event, String payload) {
+        PaymentEventOutbox paymentEventOutbox = new PaymentEventOutbox();
+
+        paymentEventOutbox.paymentId = event.getPaymentId();
+        paymentEventOutbox.payload = payload;
+        paymentEventOutbox.createdAt = event.getOccurredAt();
+
+        return paymentEventOutbox;
+    }
+
+    public void checkPublished() {
+        this.published = true;
+    }
+}

--- a/src/main/java/kr/hhplus/be/server/event/payment/outbox/PaymentEventOutboxRepository.java
+++ b/src/main/java/kr/hhplus/be/server/event/payment/outbox/PaymentEventOutboxRepository.java
@@ -1,0 +1,10 @@
+package kr.hhplus.be.server.event.payment.outbox;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public interface PaymentEventOutboxRepository {
+    void save(PaymentEventOutbox paymentEventOutbox);
+    List<PaymentEventOutbox> findByPublishedNotAndCreatedAtBefore(boolean published, LocalDateTime createdAt);
+    PaymentEventOutbox findByPaymentId(Long paymentId);
+}

--- a/src/main/java/kr/hhplus/be/server/event/payment/outbox/PaymentEventOutboxService.java
+++ b/src/main/java/kr/hhplus/be/server/event/payment/outbox/PaymentEventOutboxService.java
@@ -1,0 +1,31 @@
+package kr.hhplus.be.server.event.payment.outbox;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class PaymentEventOutboxService {
+    private final PaymentEventOutboxRepository paymentEventOutboxRepository;
+
+    @Transactional
+    public void save(PaymentEventOutbox paymentEventOutbox) {
+        paymentEventOutboxRepository.save(paymentEventOutbox);
+    }
+
+    @Transactional
+    public List<PaymentEventOutbox> findRetryEventsWithLock() {
+        return paymentEventOutboxRepository.findByPublishedNotAndCreatedAtBefore(true, LocalDateTime.now().minusMinutes(5));
+    }
+
+    @Transactional
+    public void checkPublished(Long paymentId) {
+        PaymentEventOutbox paymentEventOutbox = paymentEventOutboxRepository.findByPaymentId(paymentId);
+        paymentEventOutbox.checkPublished();
+    }
+
+}

--- a/src/main/java/kr/hhplus/be/server/infrastructure/payment/event/persistence/PaymentEventOutboxCustomJpaRepository.java
+++ b/src/main/java/kr/hhplus/be/server/infrastructure/payment/event/persistence/PaymentEventOutboxCustomJpaRepository.java
@@ -1,0 +1,30 @@
+package kr.hhplus.be.server.infrastructure.payment.event.persistence;
+
+import kr.hhplus.be.server.event.payment.outbox.PaymentEventOutbox;
+import kr.hhplus.be.server.event.payment.outbox.PaymentEventOutboxRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class PaymentEventOutboxCustomJpaRepository implements PaymentEventOutboxRepository {
+    private final PaymentEventOutboxJpaRepository paymentEventOutboxJpaRepository;
+
+    @Override
+    public void save(PaymentEventOutbox paymentEventOutbox) {
+        paymentEventOutboxJpaRepository.save(paymentEventOutbox);
+    }
+
+    @Override
+    public List<PaymentEventOutbox> findByPublishedNotAndCreatedAtBefore(boolean published, LocalDateTime createdAt) {
+        return paymentEventOutboxJpaRepository.findByPublishedNotAndCreatedAtBefore(published, createdAt);
+    }
+
+    @Override
+    public PaymentEventOutbox findByPaymentId(Long paymentId) {
+        return paymentEventOutboxJpaRepository.findByPaymentId(paymentId);
+    }
+}

--- a/src/main/java/kr/hhplus/be/server/infrastructure/payment/event/persistence/PaymentEventOutboxJpaRepository.java
+++ b/src/main/java/kr/hhplus/be/server/infrastructure/payment/event/persistence/PaymentEventOutboxJpaRepository.java
@@ -1,0 +1,17 @@
+package kr.hhplus.be.server.infrastructure.payment.event.persistence;
+
+import jakarta.persistence.LockModeType;
+import kr.hhplus.be.server.event.payment.outbox.PaymentEventOutbox;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Component
+public interface PaymentEventOutboxJpaRepository extends JpaRepository<PaymentEventOutbox, Long> {
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    List<PaymentEventOutbox> findByPublishedNotAndCreatedAtBefore(boolean published, LocalDateTime createdAt);
+    PaymentEventOutbox findByPaymentId(Long paymentId);
+}

--- a/src/main/java/kr/hhplus/be/server/scheduler/event/PaymentEventScheduler.java
+++ b/src/main/java/kr/hhplus/be/server/scheduler/event/PaymentEventScheduler.java
@@ -1,0 +1,29 @@
+package kr.hhplus.be.server.scheduler.event;
+
+import kr.hhplus.be.server.event.payment.outbox.PaymentEventOutbox;
+import kr.hhplus.be.server.event.payment.outbox.PaymentEventOutboxService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class PaymentEventScheduler {
+    private final PaymentEventOutboxService paymentEventOutboxService;
+    private final KafkaTemplate<String, String> kafkaTemplate;
+
+    private final String TOPIC = "payment-event";
+
+    @Scheduled(fixedRate = 5000)
+    @Transactional
+    public void retryPublish() {
+        List<PaymentEventOutbox> events = paymentEventOutboxService.findRetryEventsWithLock();
+        events.forEach(event -> {
+            kafkaTemplate.send(TOPIC, event.getPayload());
+        });
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -23,6 +23,10 @@ spring:
   sql:
     init:
       mode: never
+  kafka:
+    bootstrap-servers: localhost:9092
+    consumer:
+      group-id: hhplus
 
 springdoc:
   swagger-ui:

--- a/src/test/java/kr/hhplus/be/server/api/payment/PaymentControllerE2ETest.java
+++ b/src/test/java/kr/hhplus/be/server/api/payment/PaymentControllerE2ETest.java
@@ -7,7 +7,6 @@ import kr.hhplus.be.server.application.order.OrderFacade;
 import kr.hhplus.be.server.application.order.dto.OrderCommand;
 import kr.hhplus.be.server.application.order.dto.OrderItemCommand;
 import kr.hhplus.be.server.application.point.PointFacade;
-import kr.hhplus.be.server.domain.coupon.CouponService;
 import kr.hhplus.be.server.domain.order.model.OrderStatus;
 import kr.hhplus.be.server.domain.payment.model.PaymentStatus;
 import kr.hhplus.be.server.domain.point.model.Point;
@@ -15,10 +14,6 @@ import kr.hhplus.be.server.domain.product.model.Category;
 import kr.hhplus.be.server.domain.product.model.Product;
 import kr.hhplus.be.server.domain.product.model.Stock;
 import kr.hhplus.be.server.domain.user.model.User;
-import kr.hhplus.be.server.infrastructure.coupon.persistence.CouponJpaRepository;
-import kr.hhplus.be.server.infrastructure.coupon.persistence.IssuedCouponJpaRepository;
-import kr.hhplus.be.server.infrastructure.order.persistence.OrderJpaRepository;
-import kr.hhplus.be.server.infrastructure.payment.persistence.PaymentJpaRepository;
 import kr.hhplus.be.server.infrastructure.point.persistence.PointJpaRepository;
 import kr.hhplus.be.server.infrastructure.product.persistence.CategoryJapRepository;
 import kr.hhplus.be.server.infrastructure.product.persistence.ProductJpaRepository;
@@ -27,6 +22,7 @@ import kr.hhplus.be.server.infrastructure.user.persistence.UserJpaRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.kafka.test.context.EmbeddedKafka;
 import org.springframework.test.context.jdbc.Sql;
 
 import java.util.List;
@@ -36,6 +32,7 @@ import static kr.hhplus.be.server.fixture.integration.Fixture.*;
 import static org.hamcrest.Matchers.equalTo;
 
 @Sql("/clear.sql")
+@EmbeddedKafka(topics = "payment-test")
 public class PaymentControllerE2ETest extends BaseE2ETest {
     @Autowired
     private PointFacade pointFacade;

--- a/src/test/java/kr/hhplus/be/server/scheduler/event/PaymentEventSchedulerTest.java
+++ b/src/test/java/kr/hhplus/be/server/scheduler/event/PaymentEventSchedulerTest.java
@@ -1,0 +1,68 @@
+package kr.hhplus.be.server.scheduler.event;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import kr.hhplus.be.server.domain.payment.model.Payment;
+import kr.hhplus.be.server.domain.payment.model.PaymentStatus;
+import kr.hhplus.be.server.event.payment.model.PaymentCompletedEvent;
+import kr.hhplus.be.server.event.payment.outbox.PaymentEventOutbox;
+import kr.hhplus.be.server.infrastructure.payment.event.persistence.PaymentEventOutboxJpaRepository;
+import org.instancio.Instancio;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.kafka.test.context.EmbeddedKafka;
+import org.springframework.test.context.jdbc.Sql;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.instancio.Select.field;
+
+@SpringBootTest
+@Sql("/clear.sql")
+@EmbeddedKafka(topics = "payment-test")
+public class PaymentEventSchedulerTest {
+    @Autowired
+    private PaymentEventOutboxJpaRepository paymentEventOutboxRepository;
+    @Autowired
+    private PaymentEventScheduler paymentEventScheduler;
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @BeforeEach
+    public void setUp() throws JsonProcessingException {
+        Payment payment = Instancio.of(Payment.class)
+                .set(field("id"), 1L)
+                .set(field("orderId"), 1L)
+                .set(field("totalAmount"), 100_000L)
+                .set(field("discountAmount"), 0L)
+                .set(field("finalAmount"), 100_000L)
+                .set(field("status"), PaymentStatus.PENDING)
+                .create();
+        PaymentCompletedEvent paymentCompletedEvent = PaymentCompletedEvent.from(payment);
+        PaymentEventOutbox paymentEventOutbox = Instancio.of(PaymentEventOutbox.class)
+                .set(field("id"), null)
+                .set(field("paymentId"), paymentCompletedEvent.getPaymentId())
+                .set(field("payload"), objectMapper.writeValueAsString(paymentCompletedEvent))
+                .set(field("createdAt"), LocalDateTime.now().minusMinutes(10))
+                .set(field("published"), false)
+                .create();
+        paymentEventOutboxRepository.saveAndFlush(paymentEventOutbox);
+    }
+
+    @Test
+    public void 실패한_이벤트는_스케줄러를_통해_재발행된다() throws InterruptedException {
+        // given
+        Long paymentId = 1L;
+
+        // when
+        paymentEventScheduler.retryPublish();
+
+        Thread.sleep(500);
+
+        // then
+        assertThat(paymentEventOutboxRepository.findByPaymentId(paymentId).isPublished()).isEqualTo(true);
+    }
+}

--- a/src/test/resources/clear.sql
+++ b/src/test/resources/clear.sql
@@ -9,3 +9,4 @@ TRUNCATE TABLE categories;
 TRUNCATE TABLE point_histories;
 TRUNCATE TABLE points;
 TRUNCATE TABLE users;
+TRUNCATE TABLE payment_event_outbox;

--- a/src/test/resources/schema.sql
+++ b/src/test/resources/schema.sql
@@ -133,3 +133,12 @@ create table issued_coupons
     updated_at datetime(6)                null,
     constraint uk_issued_coupon_coupon_user unique (coupon_id, user_id)
 );
+
+CREATE TABLE payment_event_outbox
+(
+    id             BIGINT AUTO_INCREMENT PRIMARY KEY,
+    payment_id     BIGINT                NOT NULL,
+    payload        JSON                  NOT NULL,
+    created_at     datetime              NOT NULL,
+    published      BIT(1)                NOT NULL
+);


### PR DESCRIPTION
### **커밋 링크**
- 트랜잭션 아웃박스 패턴 적용: 12133fe0
  - 재시도 횟수를 제한하는 방식을 고려했으나, 추가하지는 못했습니다. (추후 수정하겠습니다)
    - 제한된 횟수가 지나면 실패로 처리되도록 `published`를 `status`로 변경하여 관리
    - 실패에 대한 이유를 기록
- 적용에 대한 테스트: 1aafb610
---
### **리뷰 포인트(질문)**
- 리뷰 포인트 1
  - 아웃박스 패턴이 알맞게 적용되었는지 궁금합니다.
  - 특히, 현재는 이벤트 저장 후 바로 카프카로 이벤트를 발행하고 있는데 이 방법과 스케줄러를 사용하는 방법 중 어떤 것이 더 적절할지 고민이 있습니다.
  - 또한, 적용 중 직렬화 / 역직렬화 예외에 대한 처리가 필요했는데 현재는 로그만 남기도록 처리했습니다. 보통은 어떻게 처리하는지 궁금합니다.
- 리뷰 포인트 2
  - 카프카 소비에 대한 테스트에서, 이벤트 발행에서 소비까지 걸리는 시간을 `Thread.sleep()`으로 기다리고 있는데 이 방법이 적절한지 궁금합니다. 혹은 더 적절한 방법이 있다면 알려주세요!